### PR TITLE
Fixing accidental inclusion of curly braces

### DIFF
--- a/compiler/InkParser/InkParser_Sequences.cs
+++ b/compiler/InkParser/InkParser_Sequences.cs
@@ -56,7 +56,7 @@ namespace Ink
 
         protected object SequenceTypeSymbolAnnotation()
         {
-            if(_sequenceTypeSymbols == null ) {}
+            if(_sequenceTypeSymbols == null )
                 _sequenceTypeSymbols = new CharacterSet("!&~$ ");
 
             var sequenceType = (SequenceType)0;


### PR DESCRIPTION
The inclusion of curly braces (`{}`) after the conditional on line 56 resulted in the logic intended to be conditionally executed to be unconditionally executed. It has been fixed by removing the curly braces to allow the conditional to function as a standard no-brackets, two-line conditional.